### PR TITLE
Fix Loading Non-Stack Files

### DIFF
--- a/framework/levure.livecodescript
+++ b/framework/levure.livecodescript
@@ -1441,7 +1441,8 @@ private command addFolderToFilesArray pFolder, @xFilesA
   put the number of elements of xFilesA into i
 
   repeat for each line tFile in fileListing(pFolder)
-    if isFilenameUniqueInFilesArray(tFile, xFilesA) then
+    #mikey if isFilenameUniqueInFilesArray(tFile, xFilesA) then
+    if  (tFile ends with ".livecode" OR tFile ends with ".livecodescript") AND (isFilenameUniqueInFilesArray(tFile, xFilesA)) then #mikey - don't try to load a non-stack.
       add 1 to i
       put tFile into xFilesA[i]["filename"]
     end if

--- a/utils/create_levure_app_files/app.yml
+++ b/utils/create_levure_app_files/app.yml
@@ -28,6 +28,9 @@ frontscripts:
 backscripts:
   1:
     folder: ./backscripts
+helpers:
+  1:
+    folder: ./helpers
 behaviors:
   1:
     folder: ./behaviors


### PR DESCRIPTION
Before adding a file the the list of stacks to load, checks to make sure that it has a .livecode or .livecodescript extension.