### PR TITLE
Add ios and android to preferences filename section in app.yml

### DIFF
--- a/utils/create_levure_app_files/app.yml
+++ b/utils/create_levure_app_files/app.yml
@@ -4,18 +4,22 @@ build: 1
 encrypt stacks: false
 multiple instances: false
 relaunch in background: false
+shutdown when all windows are closed: false
+creator code:
 application data:
   user:
     folder:
   shared:
     folder:
-creator code:
-shutdown when all windows are closed: false
 preferences:
   user:
     macos:
       filename:
     windows:
+      filename:
+    ios:
+      filename:
+    android:
       filename:
     linux:
       filename:


### PR DESCRIPTION
This works with existing prefFilenameForPlatform function in preferences.livecodescript. While we're at it, move creator code and shutdown lines above application data section so application data and preferences sections are next to each other.