### PR TITLE
Create android Application Support folder

### DIFF
--- a/framework/levure.livecodescript
+++ b/framework/levure.livecodescript
@@ -1056,6 +1056,10 @@ end appStackFilename
 private command createApplicationDataFolders
   local tError, tRootFolder
 
+  if the platform is "android" then
+    createSubfolders specialfolderpath("documents"), "Application Support"
+  end if
+
   if sAppA["application data"]["user"]["folder"] is not empty then
     put levureApplicationDataFolder("user") into tRootFolder
     replace "/" & sAppA["application data"]["user"]["folder"] with empty in tRootFolder


### PR DESCRIPTION
On Android, the Documents folder (specialFolderPath("documents") encompasses both user generated and application data. This creates a counterpart to the MacOS and iOS Application Support folder to store application data. Not sure where to put this, but createApplicationDataFolders seemed like a logical choice.