### PR TITLE
Fix levureApplicationDataFolder bug

### DIFF
--- a/framework/levure.livecodescript
+++ b/framework/levure.livecodescript
@@ -575,8 +575,10 @@ function levureApplicationDataFolder pUserOrShared
         break
       case "iphone"
         put specialFolderPath("library") & "/Application Support/" into tFolder
+        break
       case "android"
         put specialFolderPath("documents") & "/Application Support/" into tFolder
+        break
       default
         return empty
     end switch


### PR DESCRIPTION
Fix bug caused by missing break statements in mobile cases. The missing breaks caused application data folder creation to fail on android and iOS.