### PR TITLE
Add development build profile

### DIFF
--- a/utils/create_levure_app_files/app.yml
+++ b/utils/create_levure_app_files/app.yml
@@ -62,3 +62,4 @@ build profiles:
       android:
   release:
   beta:
+  development:


### PR DESCRIPTION
The baseline files do not allow "development" as a valid build profile. The documentation implies development is one of the baseline profiles. Without development in the app.yml file, an error is encountered when packaging an app in the development build profile.