### PR TITLE
Change `encrypt stack` to a list of random, password, or empty

### DIFF
--- a/packager/packager.livecodescript
+++ b/packager/packager.livecodescript
@@ -304,13 +304,13 @@ end _determineSigningCertificate
 
 
 private command _setPassword pStackName, pPassword
-  if revLicenseType() is not "community" then
-    if pPassword is not empty then
+  if pPassword is not empty then
+    if revLicenseType() is not "community" then
       log "  Encrypting stack" && pStackName
       set the password of stack pStackName to pPassword
+    else
+      log "  Skipping encryption in Community edition" && pStackName
     end if
-  else
-    log "  Skipping encryption in Community edition" && pStackName
   end if
   return empty
 end _setPassword
@@ -1910,9 +1910,11 @@ private command _performPackagingPrechecks pStandaloneStackFilename, @xBuildProf
     end if
   end if
 
-  # Check if encryption is supposed to happen but password is missing
-  if tError is empty then
-    if xBuildProfile is not "test" AND levureAppGet("encrypt stacks") then
+  # Get password for encryption
+  if tError is empty and xBuildProfile is not "test" then
+    if levureAppGet("encrypt stacks") is "random" then
+      put uuid() into sPassword
+    else if levureAppGet("encrypt stacks") is "password" or levureAppGet("encrypt stacks") is true then
       put levureAppGet("password") into sPassword
 
       if sPassword is empty then


### PR DESCRIPTION
`random` uses `uuid()` to change password for every build. `password` is the original behavior where developer provides a password. An empty value will not encrypt stacks. `true` is equivalent to `password` for backwards compatibility.

Docs to update when merged into `master`:
- https://github.com/trevordevore/levure/wiki/app.yml#encrypt-stacks
- https://github.com/trevordevore/levure/wiki/How-do-I-use-password-protection-for-my-application-stacks%3F

Closes #133 