### PR TITLE
Get target with loggerGetTarget()

### DIFF
--- a/framework/helpers/logger/logger_monitor.livecodescript
+++ b/framework/helpers/logger/logger_monitor.livecodescript
@@ -40,7 +40,7 @@ on preOpenCard
    set the hilite of button "LogNetworkTraffic" to false
 
    if there is a stack "Logger Library" then
-      put loggerGetTypes() into sOrigTarget
+      put loggerGetTarget() into sOrigTarget
       put loggerGetTypes() into sOrigLocTypes
 
       loggerSetTarget the long id of field "LogMessages" of me


### PR DESCRIPTION
fixes function call when setting sOrigTarget to use loggerGetTarget() in preOpenCard.