### PR TITLE
Version 0.9.2

### DIFF
--- a/framework/helpers/file_system/file_system.livecodescript
+++ b/framework/helpers/file_system/file_system.livecodescript
@@ -65,6 +65,7 @@ It can be handled like other events triggered by file/url open requests.
 on urlWakeUp pUrl
   if pURL begins with "file://" then
     delete char 1 to 7 of pUrl
+    put textdecode(urldecode(pUrl), "utf8") into pUrl
   end if
   ProcessCommandLineParameters pUrl
 end urlWakeUp

--- a/framework/helpers/logger/README.md
+++ b/framework/helpers/logger/README.md
@@ -85,7 +85,7 @@ loggerGetTypes()
 Will return
 
 ```
-developer,network,msg,extensions
+developer,error,network,msg,extensions
 ```
 
 ### Specifying where to log messages
@@ -319,6 +319,12 @@ InitializeApplication
 
 **Returns**: Empty
 
+**Parameters**:
+
+| Name | Description |
+|:---- |:----------- |
+| `pColDelim` |  One or more ascii (numeric) codes, joined by "+". |
+
 <br>
 
 ## <a name="loggerSetIncludeLogType"></a>loggerSetIncludeLogType
@@ -376,6 +382,12 @@ You can set network traffic log filters to remove sensitive data from logs that 
 
 **Returns**: Empty
 
+**Parameters**:
+
+| Name | Description |
+|:---- |:----------- |
+| `pRowDelim` |  One or more ascii (numeric) codes, joined by "+" |
+
 <br>
 
 ## <a name="loggerSetTarget"></a>loggerSetTarget
@@ -414,7 +426,7 @@ You can target the "console", a file, or a field. "console" writes the log messa
 
 | Name | Description |
 |:---- |:----------- |
-| `pTypes` |  A comma-delimited list of types to log.  Levure provides special handling for `all`, `developer`, `network`, `msg`, `extensions`.  You can also specify your own types. |
+| `pTypes` |  A comma-delimited list of types to log.  Levure provides special handling for `all`, `developer`, `network`, `msg`, `extensions`, and `error`.  You can also specify your own types. |
 
 **Description**:
 

--- a/framework/helpers/logger/README.md
+++ b/framework/helpers/logger/README.md
@@ -34,7 +34,7 @@ To add the Logger helper to your application add it under the `helpers` section 
 # app.yml
 
 helpers:
-  filename: "[[FRAMEWORK]]/helpers/logger" #in levure, "filename" points to your helper's folder.  "folder" points to a parent folder that contains multiple helper folders.
+  - filename: "[[FRAMEWORK]]/helpers/logger" #in levure, "filename" points to your helper's folder.  "folder" points to a parent folder that contains multiple helper folders.
 ```
 
 ## Configuring Logging

--- a/framework/helpers/logger/loggerLibrary.livecodescript
+++ b/framework/helpers/logger/loggerLibrary.livecodescript
@@ -453,12 +453,14 @@ private command _logLibURLMessage pMsg
 
   set the itemDelimiter to tab
   repeat for each line tFilter in sNetworkFilters
-    -- item 1 of tFilter: regex
-    -- item 2 of tFilter: replacement
+    # item 1 of tFilter: regex
+    # item 2 of tFilter: replacement
     put replaceText(pMsg, item 1 of tFilter, item 2 of tFilter) into pMsg
   end repeat
 
-  _log pMsg, "network"
+  if pMsg is not empty then
+    _log pMsg, "network"
+  end if
 end _logLibURLMessage
 
 

--- a/framework/helpers/logger/loggerLibrary.livecodescript
+++ b/framework/helpers/logger/loggerLibrary.livecodescript
@@ -1,5 +1,6 @@
 script "Logger Library"
 constant kBuiltInLogTypes = "developer,error,extensions,network,msg"
+constant kDefaultLogTypes = "developer,error,network"
 
 local sLogTarget
 local sLogA
@@ -14,7 +15,7 @@ on libraryStack
 
   local tLogTypes, tColDelim, tRowDelim, tIncludeLogType
 
-  put kBuiltInLogTypes into tLogTypes
+  put kDefaultLogTypes into tLogTypes
   if levureAppHasProperty("logger>types") then put levureAppGet ("logger>types") into tLogTypes
   loggerSetTypes tLogTypes
 

--- a/framework/helpers/logger/loggerLibrary.livecodescript
+++ b/framework/helpers/logger/loggerLibrary.livecodescript
@@ -16,6 +16,7 @@ on libraryStack
 
   put "developer" into tLogTypes
   if levureAppHasProperty("logger>types") then put levureAppGet ("logger>types") into tLogTypes
+  loggerSetTypes tLogTypes
 
   if levureAppHasProperty("logger>target") then put levureAppGet ("logger>target") into sLogTarget
 

--- a/framework/helpers/logger/loggerLibrary.livecodescript
+++ b/framework/helpers/logger/loggerLibrary.livecodescript
@@ -14,7 +14,7 @@ on libraryStack
 
   local tLogTypes, tColDelim, tRowDelim, tIncludeLogType
 
-  put "developer" into tLogTypes
+  put kBuiltInLogTypes into tLogTypes
   if levureAppHasProperty("logger>types") then put levureAppGet ("logger>types") into tLogTypes
   loggerSetTypes tLogTypes
 
@@ -90,7 +90,7 @@ end loggerGetTarget
 Summary: Set the type of messages to log.
 
 Parameters:
-pTypes: A comma-delimited list of types to log.  Levure provides special handling for `all`, `developer`, `network`, `msg`, `extensions`.  You can also specify your own types.
+pTypes: A comma-delimited list of types to log.  Levure provides special handling for `all`, `developer`, `network`, `msg`, `extensions`, and `error`.  You can also specify your own types.
 
 Description:
 Use this command to filter the types of messages that are logged.  Types that are not specified are ignored.

--- a/framework/helpers/logger/logger_monitor.livecodescript
+++ b/framework/helpers/logger/logger_monitor.livecodescript
@@ -40,7 +40,7 @@ on preOpenCard
    set the hilite of button "LogNetworkTraffic" to false
 
    if there is a stack "Logger Library" then
-      put loggerGetTypes() into sOrigTarget
+      put loggerGetTarget() into sOrigTarget
       put loggerGetTypes() into sOrigLocTypes
 
       loggerSetTarget the long id of field "LogMessages" of me

--- a/framework/helpers/logger/logger_monitor.livecodescript
+++ b/framework/helpers/logger/logger_monitor.livecodescript
@@ -44,7 +44,6 @@ on preOpenCard
       put loggerGetTypes() into sOrigLocTypes
 
       loggerSetTarget the long id of field "LogMessages" of me
-      loggerSetTypes "developer,msg,extensions,error"
    else
       set the text of field "LogMessages" of me to "Logger helper is not available"
    end if

--- a/framework/helpers/undo_manager/undoManager.livecodescript
+++ b/framework/helpers/undo_manager/undoManager.livecodescript
@@ -258,7 +258,7 @@ command undoAddAction pUndoStack, pActionName, pMementosA
   put pMementosA into sUndoLogA[pUndoStack]["undo"][tUndoIndex]["mementos"]
 
   put _getTargetForMessages(pUndoStack) into tTarget
-  dispatch "undoStoreMementos" to tTarget with pUndoStack, sUndoLogA[pUndoStack]["undo"][tUndoIndex]["mementos"]
+  dispatch "undoStoreMementos" to tTarget with pUndoStack, sUndoLogA[pUndoStack]["undo"][tUndoIndex]["mementos"], false
 
   ## Redos are wiped out. "cleanup handler" is called so program
   ## can clean up after any internal data specific to the undo array.
@@ -529,7 +529,7 @@ private command _reverseAction pUndoStack, pTargetQueue, pIndex
   end repeat
 
   put _getTargetForMessages(pUndoStack) into tTarget
-  dispatch "undoStoreMementos" to tTarget with pUndoStack, sUndoLogA[pUndoStack][tInverseQueue][tInverseIndex]["mementos"]
+  dispatch "undoStoreMementos" to tTarget with pUndoStack, sUndoLogA[pUndoStack][tInverseQueue][tInverseIndex]["mementos"], true
 
   ## Run the undo
   dispatch "undoRestoreMementos" to tTarget with pUndoStack, sUndoLogA[pUndoStack][pTargetQueue][pIndex]["mementos"]

--- a/framework/levure.livecodescript
+++ b/framework/levure.livecodescript
@@ -2952,14 +2952,22 @@ end regExForFileExtensions
 private function ensureStackNameIsPresent pFileA
   # Grab stack name in memory if not provided.
   if pFileA["name"] is empty then
-    local tStackIsLoaded, msgsAreLocked
+    local msgsAreLocked
 
+    set the wholematches to true
     put the lockMessages into msgsAreLocked
     lock messages
-    put there is a stack pFileA["filename"] into tStackIsLoaded
-    if tStackIsLoaded then
+
+    # If stack is open then don't delete from memory after getting name.
+    # This allows the framework to reload the app in the IDE without disturbing
+    # the current state.
+    if pFileA["filename"] is among the lines of the stacks then
       put the short name of stack pFileA["filename"] into pFileA["name"]
-      delete stack pFileA["filename"]
+    else
+      if there is a stack pFileA["filename"] then
+        put the short name of stack pFileA["filename"] into pFileA["name"]
+        delete stack pFileA["filename"]
+      end if
     end if
     set the lockMessages to msgsAreLocked
   end if

--- a/framework/levure.livecodescript
+++ b/framework/levure.livecodescript
@@ -2421,24 +2421,28 @@ end levureStandaloneFolder
 
 
 /**
-Summary: Returns the path of the application standalone.
+Summary: Returns the name used for the application executable on the current platform.
+
+Description:
+The standalone name is the value assigned to the Name in the Standalone Builder with the
+appropriate suffix added (e.g. `.app` for macOS, `.exe` for Windows, and nothing for Linux).
 
 Example:
-put levureStandaloneFilename() into tAppFilename
+put levureStandaloneName() into tAppExecutable
 
-Returns: Path to file
+Returns: Name
 */
-function levureStandaloneFilename
-  local tFilename
+function levureStandaloneName
+  local tName
 
   if the environment is "development" then
-    put the cRevStandaloneSettings["name"] of me into tFilename
+    put the cRevStandaloneSettings["name"] of me into tName
     switch the platform
       case "macos"
-        put ".app" after tFilename
+        put ".app" after tName
         break
       case "win32"
-        put ".exe" after tFilename
+        put ".exe" after tName
         break
       case "linux"
       default
@@ -2448,18 +2452,32 @@ function levureStandaloneFilename
     set the itemDelimiter to "/"
     switch the platform
       case "macos"
-        put specialFolderPath("engine") into tFilename
-        delete item -2 to -1 of tFilename # /Contents/MacOS
-        put the last item of tFilename into tFilename
+        put specialFolderPath("engine") into tName
+        delete item -2 to -1 of tName # /Contents/MacOS
+        put the last item of tName into tName
         break
       case "win32"
       case "linux"
       default
-        put the last item of the address into tFilename
+        put the last item of the address into tName
         break
     end switch
   end if
-  return levureStandaloneFolder() & "/" & tFilename
+
+  return tName
+end levureStandaloneName
+
+
+/**
+Summary: Returns the path of the application standalone.
+
+Example:
+put levureStandaloneFilename() into tAppFilename
+
+Returns: Path to file
+*/
+function levureStandaloneFilename
+  return levureStandaloneFolder() & "/" & levureStandaloneName()
 end levureStandaloneFilename
 
 

--- a/framework/levure.livecodescript
+++ b/framework/levure.livecodescript
@@ -842,8 +842,6 @@ Description:
 This handler targets the internal array that was created when the app.yml file
 was loaded.
 
-If the property passed in does not exist then an error will be thrown.
-
 Example:
 put levureAppGet("preferences filename>user>default")
 

--- a/framework/levure.livecodescript
+++ b/framework/levure.livecodescript
@@ -1159,8 +1159,6 @@ command levureLoadAppConfig pBuildProfile
   # set sAppFolder and load kAppStackName into memory
   loadApplicationStack
 
-  put empty into sAppA["filtered out filenames"]
-
   if (the environment is not "development") and (the uAppA of stack kAppStackName is an array) then
     # Packaged application: app stack is already in memory and all folders have been expanded
     put the uAppA of stack kAppStackName into sAppA

--- a/framework/levure.livecodescript
+++ b/framework/levure.livecodescript
@@ -730,11 +730,11 @@ end levureAppPrintConfig
 
 
 /**
-Summary: Returns an environmental variable stored in the `.env` file.
+Summary: Returns the environmental variables stored in the `.env` file.
 
 Description:
 During development you can place an `.env` file alongside the `app.yml` file. The format is
-a key=value pair, one per line. This function will return a key value.
+a key=value pair, one per line. This function will return an array of key/values.
 
 Use the `.env` file to store values you don't want stored in a git repository. For example,
 you should store the `password` used to password protect your application in the `.env` file.
@@ -746,7 +746,8 @@ your application.
 
 Example:
 # Assumes your .env file has a PASSWORD=VALUE line in it
-put levureAppGetENV("password") into tPassword
+put levureAppGetENV() into tEnvA
+put tEnvA["PASSWORD"]
 
 Returns: String
 */

--- a/framework/levure.livecodescript
+++ b/framework/levure.livecodescript
@@ -502,19 +502,8 @@ command levureInitializeFramework
 
   # extensions
   if tError is empty then
-    loadExtensions sAppA
+    loadAppExtensions
     put the result into tError
-  end if
-
-  if tError is empty then
-    repeat with i = 1 to the number of elements of sAppA["helpers"]
-      loadExtensions sAppA["helpers"][i]
-      put the result into tError
-
-      if tError is not empty then
-        exit repeat
-      end if
-    end repeat
   end if
 
   if tError is empty then
@@ -1810,6 +1799,29 @@ private command loadMessagePathAssets pArrayA
 
   return tError for error
 end loadMessagePathAssets
+
+
+private command loadAppExtensions
+  local tError
+
+  if tError is empty then
+    loadExtensions sAppA
+    put the result into tError
+  end if
+
+  if tError is empty then
+    repeat with i = 1 to the number of elements of sAppA["helpers"]
+      loadExtensions sAppA["helpers"][i]
+      put the result into tError
+
+      if tError is not empty then
+        exit repeat
+      end if
+    end repeat
+  end if
+
+  return tError for error
+end loadAppExtensions
 
 
 private command loadExtensions pArrayA

--- a/packager/packager.livecodescript
+++ b/packager/packager.livecodescript
@@ -287,21 +287,29 @@ end packagerPackageApplication
 
 
 private command _determineSigningCertificate pBuildProfile, pPlatform, @xAppA
-  local tCertName
+  local tKey, tCert
 
-  put xAppA["build profiles"][pBuildProfile]["certificates"][pPlatform]["name"] into tCertName
-  if tCertName is empty then
-    put xAppA["build profiles"]["all profiles"]["certificates"][pPlatform]["name"] into tCertName
+  if pPlatform is "macos" then
+    put "name" into tKey
+  else
+    put "filename" into tKey
   end if
 
-  if tCertName is not empty then
+  put xAppA["build profiles"][pBuildProfile]["certificates"][pPlatform][tKey] into tCert
+  if tCert is empty then
+    put xAppA["build profiles"]["all profiles"]["certificates"][pPlatform][tKey] into tCert
+  end if
+
+  if tCert is not empty then
     if pBuildProfile is "mac app store" then
-      put "3rd Party Mac Developer Application:" && tCertName into xAppA[pPlatform && "signing certificate"]
-      put "3rd Party Mac Developer Installer:" && tCertName into xAppA[pPlatform && "installer signing certificate"]
+      put "3rd Party Mac Developer Application:" && tCert into xAppA[pPlatform && "signing certificate"]
+      put "3rd Party Mac Developer Installer:" && tCert into xAppA[pPlatform && "installer signing certificate"]
     else if pBuildProfile is "mac app store development" then
-      put "Mac Developer:" && tCertName into xAppA[pPlatform && "signing certificate"]
-    else
-      put "Developer ID Application:" && tCertName into xAppA[pPlatform && "signing certificate"]
+      put "Mac Developer:" && tCert into xAppA[pPlatform && "signing certificate"]
+    else if pPlatform is "macos" then
+      put "Developer ID Application:" && tCert into xAppA[pPlatform && "signing certificate"]
+    else if pPlatform is "windows" then
+      put tCert into xAppA[pPlatform && "signing certificate"]
     end if
   end if
 end _determineSigningCertificate

--- a/packager/packager.livecodescript
+++ b/packager/packager.livecodescript
@@ -489,7 +489,7 @@ private command _dispatchPackagingComplete pBuildProfile, pAppA, pOutputFolder
   repeat for each line tFilename in tCallbackStacks
     log "Dispatching packagingComplete to stack" && tFilename
 
-    dispatch "packagingComplete" to stack tFilename with pBuildProfile, pOutputFolder
+    dispatch "packagingComplete" to stack tFilename with pBuildProfile, pOutputFolder, pAppA
   end repeat
 end _dispatchPackagingComplete
 

--- a/packager/packager.livecodescript
+++ b/packager/packager.livecodescript
@@ -273,7 +273,9 @@ command packagerPackageApplication pStandaloneStackFilename, pBuildProfile, pSim
   end repeat
   put empty into sCallbackStacksA
 
-  if tError is not empty then
+  if tError is "cancel" then
+    log "Packaging canceled"
+  else if tError is not empty then
     log "Done packaging application with error:" && tError
     answer error tError
   else
@@ -724,12 +726,12 @@ command packagerBuildStandalones pStandaloneStackFilename, pBuildForPlatform, pB
   end if
 
   if tError is empty then
+    local tStandaloneError
+
     # Assign defaultBuildFolder so that IDE doesn't ask you to save stack
     set the cRevStandaloneSettings["defaultBuildFolder"] of stack tTempStandaloneStack to tTempBuildFolder
     try
       log "Build: revSaveAsStandalone"
-
-      revSetTestEnvironment true
 
       # Intercept standaloneSaved and dispatch custom message.
       local tFrontScriptFilename
@@ -745,13 +747,17 @@ command packagerBuildStandalones pStandaloneStackFilename, pBuildForPlatform, pB
       # when loading a stack. See _unloadStackAndStackFiles in packager.livecodescript and look at adding same logic
       # to the LiveCode revSaveAsStandalone handler.
       dispatch "revSaveAsStandalone" to stack "revSaveAsStandalone" with tStack, tTempBuildFolder,, true
-      put the result into tError
+      put the result into tStandaloneError
     catch e
-      put e into tError
+      put e into tStandaloneError
     finally
-      revSetTestEnvironment false
       remove script of stack tFrontScriptFilename from front
       put empty into sBuildStandaloneA
+
+      if tStandaloneError is not empty then
+        log "revSaveAsStandalone error:" && tStandaloneError
+        put "cancel" into tError
+      end if
     end try
   end if
 

--- a/packager/packager.livecodescript
+++ b/packager/packager.livecodescript
@@ -45,7 +45,7 @@ Returns: nothing
 */
 command packagerLog pMsg
   log pMsg
-  return empty
+  return the result
 end packagerLog
 
 

--- a/packager/packager.livecodescript
+++ b/packager/packager.livecodescript
@@ -686,13 +686,17 @@ command packagerBuildStandalones pStandaloneStackFilename, pBuildForPlatform, pB
   end if
 
   if tError is empty then
+    # If this wait isn't here then the IDE reloads pStandaloneStackFilename when tTempStandaloneStack
+    # is accessed. Many precious moments of my life have been lost trying to figure out why. My best
+    # guess is that an idemessage is being sent around and some component is holding onto the stack somehow.
+    # This `wait` message is me tapping out.
+    wait 1 second with messages
+
     if not buildForDistribution then
       set the stackfiles of stack tTempStandaloneStack to empty
       set the behavior of stack tTempStandaloneStack to empty
     end if
-  end if
 
-  if tError is empty then
     set the uBuildProfile of stack tTempStandaloneStack to pBuildProfile
     set the script of stack tTempStandaloneStack to tScript
 
@@ -803,6 +807,10 @@ command packagerBuildStandalones pStandaloneStackFilename, pBuildForPlatform, pB
   set the behavior of stack pStandaloneStackFilename to empty
   set the behavior of stack pStandaloneStackFilename to the long id of stack tFrameworkFilename
   start using stack pStandaloneStackFilename
+
+  # If this wait isn't here then the IDE gets confused between pStandaloneStackFilename and tTempStandaloneStack
+  # This wait message is me giving up on trying to figure out what is going on.
+  wait 1 second with messages
 
   return tError
 end packagerBuildStandalones

--- a/packager/packager.livecodescript
+++ b/packager/packager.livecodescript
@@ -464,15 +464,15 @@ private function _packagerCallbackStacks pAppA, pBuildProfile
 end _packagerCallbackStacks
 
 
-private command _dispatchFinalizeBuildForPlatform pBuildProfile, pPlatform, pAppA, pAppFolder, pOutputFolder
+private command _dispatchFinalizeBuildForPlatform pBuildProfile, pPlatform, @xAppA, pAppFolder, pOutputFolder
   local tCallbackStacks, tFilename
 
   # Send callbacks
-  put _packagerCallbackStacks(pAppA, pBuildProfile) into tCallbackStacks
+  put _packagerCallbackStacks(xAppA, pBuildProfile) into tCallbackStacks
   repeat for each line tFilename in tCallbackStacks
     log "Dispatching finalizePackageForPlatform to stack" && tFilename
 
-    dispatch "finalizePackageForPlatform" to stack tFilename with pBuildProfile, pPlatform, pAppA, pAppFolder, pOutputFolder
+    dispatch "finalizePackageForPlatform" to stack tFilename with pBuildProfile, pPlatform, xAppA, pAppFolder, pOutputFolder
     put "" into sCallbackStacksA[ tFilename ]
   end repeat
 end _dispatchFinalizeBuildForPlatform
@@ -492,15 +492,15 @@ private command _dispatchFinalizePackagedAssets pBuildProfile, pPlatform, @xAppA
 end _dispatchFinalizePackagedAssets
 
 
-private command _dispatchPackagingComplete pBuildProfile, pAppA, pOutputFolder
+private command _dispatchPackagingComplete pBuildProfile, @xAppA, pOutputFolder
   local tCallbackStacks, tFilename
 
   # Send callbacks
-  put _packagerCallbackStacks(pAppA, pBuildProfile) into tCallbackStacks
+  put _packagerCallbackStacks(xAppA, pBuildProfile) into tCallbackStacks
   repeat for each line tFilename in tCallbackStacks
     log "Dispatching packagingComplete to stack" && tFilename
 
-    dispatch "packagingComplete" to stack tFilename with pBuildProfile, pOutputFolder, pAppA
+    dispatch "packagingComplete" to stack tFilename with pBuildProfile, pOutputFolder, xAppA
   end repeat
 end _dispatchPackagingComplete
 

--- a/packager/packager.livecodescript
+++ b/packager/packager.livecodescript
@@ -1088,7 +1088,7 @@ end _packageHelpers
 
 
 private command _packageHelper pBuildProfile, @xHelperA, pPlatform, pOutputFolder, pExecutableOutputFolder
-  local tError, tExclusions, tDestFolder, tExecutableDestFolder, tFolder, tFolderA
+  local tError, tExclusions, tDestFolder, tExecutableDestFolder, tFilename, tFolderA, tFileA
   local tKey, i
   local tRootFolder
   local tIndex, tHelpersA
@@ -1259,14 +1259,36 @@ private command _packageHelper pBuildProfile, @xHelperA, pPlatform, pOutputFolde
 
     # folders
     repeat for each element tFolderA in xHelperA["package folders"]
-      put xHelperA["filename"] & "/" & tFolderA["filename"] into tFolder
-      if not (the last item of tFolder begins with ".") AND not (tFolder ends with ".bundle") AND there is not a folder (tDestFolder & "/" & the last item of tFolder) then
-        log "  Adding helper additional folder:" && tFolder
-        log "    to folder:" && tDestFolder & "/" & the last item of tFolder
+      if not _shouldAssetBeDistributed(tFolderA, pBuildProfile, pPlatform) then
+        log "  Skipping helper folder:" && tFolderA["filename"]
+        next repeat
+      end if
 
-        _fileCopyFolder tFolder, tDestFolder & "/" & the last item of tFolder
+      put xHelperA["filename"] & "/" & tFolderA["filename"] into tFilename
+      if not (the last item of tFilename begins with ".") AND not (tFilename ends with ".bundle") AND there is not a folder (tDestFolder & "/" & the last item of tFilename) then
+        log "  Adding helper additional folder:" && tFilename
+        log "    to folder:" && tDestFolder & "/" & the last item of tFilename
+
+        _fileCopyFolder tFilename, tDestFolder & "/" & the last item of tFilename
         put the result into tError
       end if
+
+      if tError is not empty then exit repeat
+    end repeat
+
+    # files
+    repeat for each element tFileA in xHelperA["package files"]
+      if not _shouldAssetBeDistributed(tFileA, pBuildProfile, pPlatform) then
+        log "  Skipping helper file:" && tFileA["filename"]
+        next repeat
+      end if
+
+      put xHelperA["filename"] & "/" & tFileA["filename"] into tFilename
+      log "  Adding helper additional file:" && tFilename
+      log "    to folder:" && tDestFolder
+
+      _fileCopyFile tFilename, tDestFolder & "/" & the last item of tFilename
+      put the result into tError
 
       if tError is not empty then exit repeat
     end repeat

--- a/packager/packager.livecodescript
+++ b/packager/packager.livecodescript
@@ -63,7 +63,7 @@ command packagerPackageApplication pStandaloneStackFilename, pBuildProfile, pSim
   if pSimulator is "ios" then
     put false into tBuildStandalone
     put "ios" into tStandaloneBuilderPlatforms
-  else if pBuildProfile is "android" then
+  else if pSimulator is "android" then
     put false into tBuildStandalone
     put "android" into tStandaloneBuilderPlatforms
   else

--- a/packager/packager.livecodescript
+++ b/packager/packager.livecodescript
@@ -2244,9 +2244,9 @@ private command _signFile pFilename, pCertificate
     put _bundleEntitlementFile(pFilename) into tEntitlementsFile
 
     if tEntitlementsFile is not empty then
-      put format("codesign --verbose --force -s \"%s\" --entitlements \"%s\" \"%s\"", pCertificate, tEntitlementsFile, pFilename) into tCmd
+      put format("codesign --verbose --force --timestamp -s \"%s\" --entitlements \"%s\" \"%s\"", pCertificate, tEntitlementsFile, pFilename) into tCmd
     else
-      put format("codesign --verbose --force -s \"%s\" \"%s\"", pCertificate, pFilename) into tCmd
+      put format("codesign --verbose --force --timestamp -s \"%s\" \"%s\"", pCertificate, pFilename) into tCmd
     end if
 
     get shell(tCmd)

--- a/packager/packager.livecodescript
+++ b/packager/packager.livecodescript
@@ -39,6 +39,17 @@ end resetLogging
 
 
 /**
+Summary: Adds a message to the build log file.
+
+Returns: nothing
+*/
+command packagerLog pMsg
+  log pMsg
+  return empty
+end packagerLog
+
+
+/**
 Summary: Packages an application for configured platforms.
 
 pStandaloneStackFilename: The filename of the standalone stack.


### PR DESCRIPTION
- Stacks that are open are no longer removed from memory when calling `levureInitializeFramework`. This allows the call to be made in the IDE while editing your app in order to load files that have been added to disk since the application was opened in the IDE.
- Allow helpers to define conditions based on engine version, platform, and `distribute` flag for packaging folders and files.
- Logger improvements.
- Allow for windows to define a filename where the certificate file is located.
- Use timestamp when signing apps on macOS.
- Building standalone now reports errors and other standalone building improvements.
- URL is properly decoded in `urlWakeup`.
- Added `pUndoing` parameter to `undoRestoreMementos`.
- Updates to examples.
- App array is now passed as the third parameter to `packagingComplete`.
- `finalizePackageForPlatform` can now modify the app array.
- Added `packagerLog` so that helpers can add entries to the build log file during packaging.
- Network activity is no longer logged if the message is empty after being run through the network filters.
- Added `levureStandaloneName()`.