### PR TITLE
Fix YAML single quoted string truncation at `#`

### DIFF
--- a/framework/levure.livecodescript
+++ b/framework/levure.livecodescript
@@ -3608,17 +3608,27 @@ private function __unquotedCharOffset pChar, pLine
   local tOffset = 0
   local tChar
   local tInQuote = "false"
+  local tQuoteChar, tQuoteEscapeChar
 
   repeat with tOffset = 1 to the number of chars of pLine
     put char tOffset of pLine into tChar
 
-    if tInQuote and tChar is "\" and char tOffset+1 of pLine is quote then
+    if tInQuote and tChar is tQuoteEscapeChar and \
+        char tOffset+1 of pLine is tQuoteChar then
       add 1 to tOffset
       next repeat
     end if
 
-    if tChar is quote then
+    if tInQuote and tChar is tQuoteChar then
       put not tInQuote into tInQuote
+    else if not tInQuote and tChar is quote then
+      put quote into tQuoteChar
+      put "\" into tQuoteEscapeChar
+      put true into tInQuote
+    else if not tInQuote and tChar is "'" then
+      put "'"  into tQuoteChar
+      put "'" into tQuoteEscapeChar
+      put true into tInQuote
     else if tChar is pChar and not tInQuote then
       return tOffset
     end if


### PR DESCRIPTION
This patch fixes the truncation of single quoted strings at the comment char.
For example the following string `'bar#baz'` was being truncated at `#` because
`__unquotedCharOffset` was not checking for single quoted strings.

Closes #162 