### PR TITLE
Fix `_useFileWithThisEngine` operator evaluation

### DIFF
--- a/framework/levure.livecodescript
+++ b/framework/levure.livecodescript
@@ -2223,16 +2223,16 @@ private function _useFileWithThisEngine pVersionRange
 
   switch tOperator
     case "<"
-      return tVersion < tEngineVersion
+      return tEngineVersion < tVersion
 
     case ">"
-      return tVersion > tEngineVersion
+      return tEngineVersion > tVersion
 
     case "<="
-        return tVersion <= tEngineVersion
+        return tEngineVersion <= tVersion
 
     case ">="
-      return tVersion >= tEngineVersion
+      return tEngineVersion >= tVersion
 
     default
       return false


### PR DESCRIPTION
This patch fixes the operator evaluation in the `_useFileWithThisEngine` function to ensure the `engine version` property of externals and extensions behave as documented.

Closes #191 