### PR TITLE
[[ Issue 196 ]] Fix files not found on web

### DIFF
--- a/packager/packager.livecodescript
+++ b/packager/packager.livecodescript
@@ -1928,6 +1928,9 @@ private function _generateStartupScript pRelativeFrameworkPath, pRelativeAppPath
           _qstr("if the platform is `macos` then") & cr & \
           _qstr("put resolvePath(`" & tAppStackFilename & "`, item 1 to -2 of the engine folder & `/Resources/_MacOS`) into tAppStackFilename") & cr & \
           _qstr("put resolvePath(`" & tFrameworkFilename & "`, item 1 to -2 of the engine folder & `/Resources/_MacOS`) into tFrameworkFilename") & cr & \
+          _qstr("else if the platform is `web` then") & cr & \
+          _qstr("put resolvePath(`" & tAppStackFilename & "`, the engine folder & `/standalone`) into tAppStackFilename") & cr & \
+          _qstr("put resolvePath(`" & tFrameworkFilename & "`, the engine folder & `/standalone`) into tFrameworkFilename") & cr & \
           "else" & cr & \
           _qstr("put resolvePath(`" & tAppStackFilename & "`, the engine folder) into tAppStackFilename") & cr & \
           _qstr("put resolvePath(`" & tFrameworkFilename & "`, the engine folder) into tFrameworkFilename") & cr & \


### PR DESCRIPTION
This patch fixes an issue where the startup script does not find the app or framework files in the generated startup script.

Closes #196 