### PR TITLE
Re-sequence distributed file assets array

### DIFF
--- a/packager/packager.livecodescript
+++ b/packager/packager.livecodescript
@@ -1485,6 +1485,8 @@ private command _packageFiles pBuildProfile, pPlatform, @xAppA, pOutputFolder
 
       local tFilename
 
+      local tIndex
+      put 0 into tIndex
       repeat with i = 1 to the number of elements of xAppA[tLookupA]
         # Send callbacks
         if xAppA["registered components"]["files"][tKey]["callback stackfile"] is not empty then
@@ -1517,11 +1519,13 @@ private command _packageFiles pBuildProfile, pPlatform, @xAppA, pOutputFolder
         end if
 
         if tError is empty then
-          put _makeRelativePath(xAppA[tLookupA][i]["filename"], levureAppFolder()) into tCompsA[i]["filename"]
+          # Create new array with excluded elements removed
+          add 1 to tIndex
+          put _makeRelativePath(xAppA[tLookupA][i]["filename"],levureAppFolder()) into tCompsA[tIndex]["filename"]
           repeat for each key tProp in xAppA[tLookupA][i]
             if tProp is "filename" then next repeat
 
-            put xAppA[tLookupA][i][tProp] into tCompsA[i][tProp]
+            put xAppA[tLookupA][i][tProp] into tCompsA[tIndex][tProp]
           end repeat
         end if
 


### PR DESCRIPTION
This patch ensures the distributed file assets array is re-sequenced excluding the file assets that are not being distributed. This resolves an issue where `_loadRegisteredKeyFiles` iterates the files assuming 1..n index.

Closes #200 