### PR TITLE
Update helper callback stack paths in packaged app

### DIFF
--- a/framework/levure.livecodescript
+++ b/framework/levure.livecodescript
@@ -1182,6 +1182,22 @@ command levureLoadAppConfig pBuildProfile
     put expandHelperAssetsFileReferenceArray(pBuildProfile, sAppA["helpers"], sAppFolder) into sAppA["helpers"]
     put the result into tError
 
+    /* Update callback stackfiles */
+    local i, tKeyIndex, tKind, tHelperFilename
+    repeat with i = 1 to the number of elements of sAppA["helpers"]
+      repeat with tKeyIndex = 1 to the number of elements of sAppA["helpers"][i]["register components"]
+        put sAppA["helpers"][i]["register components"][tKeyIndex]["key"] into tKey
+        put sAppA["helpers"][i]["register components"][tKeyIndex]["kind"] into tKind
+
+        if sAppA["helpers"][i]["register components"][tKeyIndex]["callback stackfile"] is not empty then
+          put resolveFilenameReference( \
+              sAppA["helpers"][i]["register components"][tKeyIndex]["callback stackfile"], \
+              sAppA["helpers"][i]["filename"]) \
+            into sAppA["registered components"][tKind][tKey]["callback stackfile"]
+        end if
+      end repeat
+    end repeat
+
     if tError is empty then
       resolveHelperAssets pBuildProfile
       put the result into tError
@@ -1205,7 +1221,7 @@ command levureLoadAppConfig pBuildProfile
     end if
 
     if tError is empty then
-      local i, j
+      local j
       local tFilesA
 
       ##########
@@ -1258,7 +1274,7 @@ command levureLoadAppConfig pBuildProfile
       # Get keys registered by helpers
       ##########
       if tError is empty then
-        local tKeyIndex, tKind, tCallbackStack, k
+        local tCallbackStack, k
 
         repeat with i = 1 to the number of elements of sAppA["helpers"]
           repeat with tKeyIndex = 1 to the number of elements of sAppA["helpers"][i]["register components"]

--- a/packager/packager.livecodescript
+++ b/packager/packager.livecodescript
@@ -456,6 +456,11 @@ private command _pruneAppArray @xAppA, pBuildProfile, pPlatform
     delete local xAppA["preferences filename"]["shared"][tKey]
   end repeat
 
+  /* Delete callback stackfiles that will be resolved at runtime */
+  repeat for each key tKey in xAppA["registered components"]["files"]
+    delete local xAppA["registered components"]["files"][tKey]["callback stackfile"]
+  end repeat
+
   return empty for error
 end _pruneAppArray
 


### PR DESCRIPTION
This patch resolves an error where the registerd key file callback stacks paths are retained from the build and not resolved at runtime for the packaged app. An error is therefore thrown in the packaged app at startup if there is both a callback stackfile and distributed files.

An error will still be thrown if the callback stackfile was not distributed, however, that is a valid error given the registered key files were distributed and they require the callback stackfile.

Closes #202 