### PR TITLE
Add support for packaging registered files to alternate relative folder

### DIFF
--- a/packager/packager.livecodescript
+++ b/packager/packager.livecodescript
@@ -1523,7 +1523,22 @@ private command _packageFiles pBuildProfile, pPlatform, @xAppA, pOutputFolder
         end if
 
         put xAppA[tLookupA][i]["filename"] into tFilename
-        replace levureAppFolder() with pOutputFolder in tFilename
+
+        # Figure out destination
+        local tDestination
+        put xAppA[tLookupA][i]["destination"] into tDestination
+
+        if tDestination is empty then
+          replace levureAppFolder() with pOutputFolder in tFilename
+        else
+          put _normalizeRelativeFilename(tDestination) into tDestination
+          # tDestination may have been `./` or `/`.
+          if the last char of tDestination is "/" then
+            delete the last char of tDestination
+          end if
+          put tDestination & "/" & the last item of tFilename into tDestination
+          put pOutputFolder & "/" & tDestination into tFilename
+        end if
 
         packagerCreateAllFoldersInPath item 1 to -2 of tFilename, pOutputFolder
         put _errorMsg("creating folder" && item 1 to -2 of tFilename, the result) into tError
@@ -1537,7 +1552,12 @@ private command _packageFiles pBuildProfile, pPlatform, @xAppA, pOutputFolder
         if tError is empty then
           # Create new array with excluded elements removed
           add 1 to tIndex
-          put _makeRelativePath(xAppA[tLookupA][i]["filename"],levureAppFolder()) into tCompsA[tIndex]["filename"]
+          if tDestination is not empty then
+            put "./" & tDestination into tCompsA[tIndex]["filename"]
+          else
+            put _makeRelativePath(xAppA[tLookupA][i]["filename"],levureAppFolder()) \
+                into tCompsA[tIndex]["filename"]
+          end if
           repeat for each key tProp in xAppA[tLookupA][i]
             if tProp is "filename" then next repeat
 


### PR DESCRIPTION
This patch adds support for specifying a `destination` key in registered component files that are to be distributed when packaging. This allows the files to be located outside the app folder during development and then distributed into a relative path when packaged.

Closes #215